### PR TITLE
Use AWS Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This is designed to handle failure gracefully. If processing of a survey fails, 
 
 ActionKit tables can be in a separate schema, but currently must be accessible within the same database connection.
 
-## settings.py
+## Settings
 
-Run `cp settings.py.example settings.py` and fill in any values needed for your environment.
+Settings are fetched directly from AWS Secrets Manager using the secret name `ak-survey-results`. 
 
 ## Command line usage
 

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -15,6 +15,7 @@ ARG_DEFINITIONS = {
     'DB_NAME': 'Database name',
     'DB_SCHEMA_AK': 'Database schema for ActionKit tables',
     'DB_SCHEMA_SURVEY': 'Database schema for survey results tables',
+    'DB_VARCHAR_COL': 'VARCHAR column type and length. VARCHAR on Postgres, VARCHAR(MAX) on Redshift',
     'FUNCTION': ('Function to call, e.g. '
                  'survey_refresh_info, process_recent_actions_for_survey'),
     'PAGE_ID': ('Survey page ID for survey_refresh_info, '
@@ -30,7 +31,6 @@ REQUIRED_ARGS = [
 ]
 
 settings = get_settings(ARG_DEFINITIONS, 'ak-survey-results')
-
 
 class PageNotFoundException(Exception):
     '''Raise this when requested page is not found'''
@@ -260,7 +260,7 @@ class AKSurveyResults:
         DROP TABLE IF EXISTS %s.page_%d
         """ % (self.settings['DB_SCHEMA_SURVEY'], int(page_id))
         self.database_cursor.execute(drop_query)
-        create_columns = ['%s VARCHAR(MAX)' % column for column in column_list]
+        create_columns = ['%s %s' % (column, self.settings['DB_VARCHAR_COL']) for column in column_list]
         create_columns.insert(0, 'action_id INTEGER')
         create_query = """
         CREATE TABLE %s.page_%d (%s)

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -27,7 +27,7 @@ ARG_DEFINITIONS = {
 }
 
 REQUIRED_ARGS = [
-    'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PWD', 'DB_NAME', 'FUNCTION'
+    'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PASS', 'DB_NAME', 'DB_VARCHAR_COL', 'FUNCTION'
 ]
 
 settings = get_settings(ARG_DEFINITIONS, 'ak-survey-results')

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -15,7 +15,7 @@ ARG_DEFINITIONS = {
     'DB_NAME': 'Database name',
     'DB_SCHEMA_AK': 'Database schema for ActionKit tables',
     'DB_SCHEMA_SURVEY': 'Database schema for survey results tables',
-    'DB_VARCHAR_COL': 'VARCHAR column type and length. VARCHAR on Postgres, VARCHAR(MAX) on Redshift',
+    'DB_TYPE': 'Database type: PostgreSQL or Redshift',
     'FUNCTION': ('Function to call, e.g. '
                  'survey_refresh_info, process_recent_actions_for_survey'),
     'PAGE_ID': ('Survey page ID for survey_refresh_info, '
@@ -25,10 +25,6 @@ ARG_DEFINITIONS = {
     'LAMBDA': ('(Optional) AWS Lambda function to process surveys. '
                'If not supplied, surveys are processed synchronously.')
 }
-
-REQUIRED_ARGS = [
-    'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PASS', 'DB_NAME', 'DB_VARCHAR_COL', 'FUNCTION'
-]
 
 settings = get_settings(ARG_DEFINITIONS, 'ak-survey-results')
 
@@ -43,6 +39,8 @@ class PageNotSurveyException(Exception):
 class PageNotLoadedException(Exception):
     '''Raise this when requested page is not yet loaded'''
 
+class InvalidDbTypeException(Exception):
+    '''Raise this when the specified database type is not handled'''
 
 class AKSurveyResults:
 
@@ -63,6 +61,13 @@ class AKSurveyResults:
         )
         self.custom_slugify = Slugify(to_lower=True)
         self.custom_slugify.separator = '_'
+        self.varchar_col_type = ''
+        if self.settings['DB_TYPE'].lower() == 'redshift':
+            self.varchar_col_type = 'VARCHAR(MAX)'
+        elif self.settings['DB_TYPE'].lower() == 'postgresql':
+            self.varchar_col_type = 'VARCHAR'
+        else:
+            raise InvalidDbTypeException('Database type %s not found.' % self.settings['DB_TYPE'])
 
     def survey_refresh_info(self, page_id):
         """
@@ -260,7 +265,7 @@ class AKSurveyResults:
         DROP TABLE IF EXISTS %s.page_%d
         """ % (self.settings['DB_SCHEMA_SURVEY'], int(page_id))
         self.database_cursor.execute(drop_query)
-        create_columns = ['%s %s' % (column, self.settings['DB_VARCHAR_COL']) for column in column_list]
+        create_columns = ['%s %s' % (column, self.varchar_col_type) for column in column_list]
         create_columns.insert(0, 'action_id INTEGER')
         create_query = """
         CREATE TABLE %s.page_%d (%s)

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -1,19 +1,11 @@
 import boto3
 import datetime
-import os
-import sys
 from json import dumps
 
 import psycopg2
 import psycopg2.extras
 from slugify.main import Slugify
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-if os.path.exists(os.path.join(BASE_DIR, 'settings.py')):
-    import settings
-else:
-    settings = {}
+from pywell.entry_points import get_settings
 
 ARG_DEFINITIONS = {
     'DB_HOST': 'Database host IP or hostname',
@@ -37,6 +29,8 @@ REQUIRED_ARGS = [
     'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PWD', 'DB_NAME', 'FUNCTION'
 ]
 
+settings = get_settings(ARG_DEFINITIONS, 'ak-survey-results')
+
 
 class PageNotFoundException(Exception):
     '''Raise this when requested page is not found'''
@@ -58,11 +52,11 @@ class AKSurveyResults:
         """
         self.settings = settings
         self.database = psycopg2.connect(
-            host=self.settings.DB_HOST,
-            port=self.settings.DB_PORT,
-            user=self.settings.DB_USER,
-            password=self.settings.DB_PASS,
-            database=self.settings.DB_NAME
+            host=self.settings['DB_HOST'],
+            port=self.settings['DB_PORT'],
+            user=self.settings['DB_USER'],
+            password=self.settings['DB_PASS'],
+            database=self.settings['DB_NAME']
         )
         self.database_cursor = self.database.cursor(
             cursor_factory=psycopg2.extras.RealDictCursor
@@ -86,9 +80,9 @@ class AKSurveyResults:
         WHERE p.id = %d
         GROUP BY 1,2,3,4
         """ % (
-            self.settings.DB_SCHEMA_AK,
-            self.settings.DB_SCHEMA_SURVEY,
-            self.settings.DB_SCHEMA_AK,
+            self.settings['DB_SCHEMA_AK'],
+            self.settings['DB_SCHEMA_SURVEY'],
+            self.settings['DB_SCHEMA_AK'],
             int(page_id)
         )
         self.database_cursor.execute(survey_info_query)
@@ -109,7 +103,7 @@ class AKSurveyResults:
         SELECT COUNT(pa.action_id) AS saved_count
         FROM %s.page_%d pa
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id)
         )
         self.database_cursor.execute(saved_count_query)
@@ -130,7 +124,7 @@ class AKSurveyResults:
         ORDER BY a.created_at ASC
         LIMIT 10000
         """ % (
-            self.settings.DB_SCHEMA_AK,
+            self.settings['DB_SCHEMA_AK'],
             int(page_id),
             since
         )
@@ -152,14 +146,14 @@ class AKSurveyResults:
         """
         Get all field values for given list of action IDs.
         """
-        excludes = self.settings.COLUMN_EXCLUDES.split(',')
+        excludes = self.settings['COLUMN_EXCLUDES'].split(',')
         values_query = """
         SELECT af.parent_id AS action_id, af.name, af.value
         FROM %s.core_actionfield af
         WHERE af.parent_id IN (%s)
         AND NOT af.name = ANY(%s)
         """ % (
-            self.settings.DB_SCHEMA_AK,
+            self.settings['DB_SCHEMA_AK'],
             ', '.join([str(id) for id in action_ids]),
             '%s'
         )
@@ -239,7 +233,7 @@ class AKSurveyResults:
         """
         Full column list for given survey page_id.
         """
-        excludes = self.settings.COLUMN_EXCLUDES.split(',')
+        excludes = self.settings['COLUMN_EXCLUDES'].split(',')
         column_query = """
         SELECT DISTINCT af.name
         FROM %s.core_actionfield af
@@ -247,8 +241,8 @@ class AKSurveyResults:
         WHERE a.page_id = %d
         AND NOT af.name = ANY(%s)
         """ % (
-            self.settings.DB_SCHEMA_AK,
-            self.settings.DB_SCHEMA_AK,
+            self.settings['DB_SCHEMA_AK'],
+            self.settings['DB_SCHEMA_AK'],
             int(page_id),
             '%s'
         )
@@ -264,14 +258,14 @@ class AKSurveyResults:
         """
         drop_query = """
         DROP TABLE IF EXISTS %s.page_%d
-        """ % (self.settings.DB_SCHEMA_SURVEY, int(page_id))
+        """ % (self.settings['DB_SCHEMA_SURVEY'], int(page_id))
         self.database_cursor.execute(drop_query)
         create_columns = ['%s VARCHAR(MAX)' % column for column in column_list]
         create_columns.insert(0, 'action_id INTEGER')
         create_query = """
         CREATE TABLE %s.page_%d (%s)
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id),
             ', '.join(create_columns)
         )
@@ -295,7 +289,7 @@ class AKSurveyResults:
         delete_query = """
         DELETE FROM %s.page_%d WHERE action_id = ANY(%s)
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id),
             '%s'
         )
@@ -304,7 +298,7 @@ class AKSurveyResults:
         insert_query = """
         INSERT INTO %s.page_%d (%s) VALUES %s
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id),
             ', '.join(insert_columns),
             """,
@@ -327,7 +321,7 @@ class AKSurveyResults:
         VALUES
         (%d, '%s', '1900-01-01 00:00:00')
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id),
             ','.join(column_list)
         )
@@ -342,7 +336,7 @@ class AKSurveyResults:
         DELETE FROM %s.pages
         WHERE page_id = %d
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             int(page_id)
         )
         self.database_cursor.execute(delete_query)
@@ -359,7 +353,7 @@ class AKSurveyResults:
         SET last_refresh = %s
         WHERE page_id = %d
         """ % (
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_SURVEY'],
             last_refresh,
             int(page_id)
         )
@@ -387,9 +381,9 @@ class AKSurveyResults:
         ORDER BY p.id DESC
         LIMIT %d
         """ % (
-            self.settings.DB_SCHEMA_AK,
-            self.settings.DB_SCHEMA_AK,
-            self.settings.DB_SCHEMA_SURVEY,
+            self.settings['DB_SCHEMA_AK'],
+            self.settings['DB_SCHEMA_AK'],
+            self.settings['DB_SCHEMA_SURVEY'],
             count
         )
         self.database_cursor.execute(needs_update_query)
@@ -544,7 +538,7 @@ def aws_lambda(event, context):
             event[argname] = kwargs.get(argname)
     for argname, helptext in ARG_DEFINITIONS.items():
         if not event.get(argname, False):
-            event[argname] = getattr(settings, argname, False)
+            event[argname] = settings.get(argname, False)
     print(event.get('FUNCTION', ''), 'FUNCTION')
     print(event.get('PAGE_ID', ''), 'PAGE_ID')
     print(event.get('SINCE', ''), 'SINCE')
@@ -567,7 +561,7 @@ if __name__ == '__main__':
     for argname, helptext in ARG_DEFINITIONS.items():
         parser.add_argument(
             '--%s' % argname, dest=argname, help=helptext,
-            default=getattr(settings, argname, False)
+            default=settings.get(argname, False)
         )
 
     args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ awesome-slugify==1.6.5
 boto3==1.12.1
 psycopg2-binary==2.8.4
 zappa==0.49.0
+git+https://github.com/moveonorg/pywell@main#egg=pywell

--- a/settings.py.example
+++ b/settings.py.example
@@ -6,7 +6,7 @@ settings = {
     'DB_NAME': '',
     'DB_SCHEMA_AK': 'ak',
     'DB_SCHEMA_SURVEY': 'survey_results',
-    'DB_VARCHAR_COL': '',
+    'DB_TYPE': '',
     'FUNCTION': 'survey_refresh_info',
     'PAGE_ID': 1,
     'SINCE': 60,

--- a/settings.py.example
+++ b/settings.py.example
@@ -9,6 +9,6 @@ settings = {
     'DB_VARCHAR_COL': '',
     'FUNCTION': 'survey_refresh_info',
     'PAGE_ID': 1,
-    'MINUTES': 60,
+    'SINCE': 60,
     'COLUMN_EXCLUDES': ''
 }

--- a/settings.py.example
+++ b/settings.py.example
@@ -6,6 +6,7 @@ settings = {
     'DB_NAME': '',
     'DB_SCHEMA_AK': 'ak',
     'DB_SCHEMA_SURVEY': 'survey_results',
+    'DB_VARCHAR_COL': '',
     'FUNCTION': 'survey_refresh_info',
     'PAGE_ID': 1,
     'MINUTES': 60,

--- a/settings.py.example
+++ b/settings.py.example
@@ -1,11 +1,13 @@
-DB_USER = ''
-DB_HOST = ''
-DB_PORT = ''
-DB_PASS = ''
-DB_NAME = ''
-DB_SCHEMA_AK = 'ak'
-DB_SCHEMA_SURVEY = 'survey_results'
-FUNCTION = 'survey_refresh_info'
-PAGE_ID = 1
-MINUTES = 60
-COLUMN_EXCLUDES = ''
+settings = {
+    'DB_USER': '',
+    'DB_HOST': '',
+    'DB_PORT': 0000,
+    'DB_PASS': '',
+    'DB_NAME': '',
+    'DB_SCHEMA_AK': 'ak',
+    'DB_SCHEMA_SURVEY': 'survey_results',
+    'FUNCTION': 'survey_refresh_info',
+    'PAGE_ID': 1,
+    'MINUTES': 60,
+    'COLUMN_EXCLUDES': ''
+}

--- a/test_ak_survey_results.py
+++ b/test_ak_survey_results.py
@@ -23,7 +23,7 @@ class Test:
             last_refresh TIMESTAMP,
             column_list %s
         )
-        """ % (settings['DB_SCHEMA_SURVEY'], settings['DB_VARCHAR_COL'])
+        """ % (settings['DB_SCHEMA_SURVEY'], self.survey_results.varchar_col_type)
         self.survey_results.database_cursor.execute(create_pages_table_query)
 
         create_ak_schema_query = """
@@ -55,7 +55,7 @@ class Test:
             name VARCHAR(765),
             value %s
         )
-        """ % (settings['DB_SCHEMA_AK'], settings['DB_VARCHAR_COL'])
+        """ % (settings['DB_SCHEMA_AK'], self.survey_results.varchar_col_type)
         self.survey_results.database_cursor.execute(
             create_actionfield_table_query
         )
@@ -91,7 +91,7 @@ class Test:
             action_id INTEGER,
             processed %s
         )
-        """ % (settings['DB_SCHEMA_SURVEY'], settings['DB_VARCHAR_COL'])
+        """ % (settings['DB_SCHEMA_SURVEY'], self.survey_results.varchar_col_type)
         self.survey_results.database_cursor.execute(create_page_query)
 
         process_page_query = """

--- a/test_ak_survey_results.py
+++ b/test_ak_survey_results.py
@@ -1,20 +1,20 @@
 import pytest
-import test_settings
+from test_settings import settings
 from ak_survey_results import AKSurveyResults
 from ak_survey_results import PageNotFoundException
 from ak_survey_results import PageNotSurveyException
 from ak_survey_results import PageNotLoadedException
 from ak_survey_results import Struct
 
-
 class Test:
 
     def setup(self):
-        self.survey_results = AKSurveyResults(test_settings)
+
+        self.survey_results = AKSurveyResults(settings)
 
         create_survey_schema_query = """
         CREATE SCHEMA %s
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(create_survey_schema_query)
 
         create_pages_table_query = """
@@ -23,12 +23,12 @@ class Test:
             last_refresh TIMESTAMP,
             column_list VARCHAR(MAX)
         )
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(create_pages_table_query)
 
         create_ak_schema_query = """
         CREATE SCHEMA %s
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(create_ak_schema_query)
 
         create_page_table_query = """
@@ -36,7 +36,7 @@ class Test:
             id INTEGER,
             type VARCHAR(765)
         )
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(create_page_table_query)
 
         create_action_table_query = """
@@ -45,7 +45,7 @@ class Test:
             page_id INTEGER,
             created_at TIMESTAMP
         )
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(create_action_table_query)
 
         create_actionfield_table_query = """
@@ -55,7 +55,7 @@ class Test:
             name VARCHAR(765),
             value VARCHAR(MAX)
         )
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(
             create_actionfield_table_query
         )
@@ -65,7 +65,7 @@ class Test:
         VALUES
         (1, 'Donation'), (2, 'Survey'),
         (3, 'Survey'), (4, 'Survey')
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(page_query)
 
         action_query = """
@@ -74,7 +74,7 @@ class Test:
         (1, 2, '2018-10-01 01:01:01'),
         (2, 3, '2018-10-05 01:01:01'),
         (3, 4, '2018-10-06 01:01:01')
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(action_query)
 
         actionfield_query = """
@@ -83,7 +83,7 @@ class Test:
         (1, 1, 'name', 'value'),
         (2, 2, 'another', 'a value'),
         (3, 3, 'processed', 'yes')
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(actionfield_query)
 
         create_page_query = """
@@ -91,19 +91,19 @@ class Test:
             action_id INTEGER,
             processed VARCHAR(MAX)
         )
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(create_page_query)
 
         process_page_query = """
         INSERT INTO %s.pages (page_id, last_refresh, column_list)
         VALUES (4, '2018-10-06 01:01:01', 'processed')
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(process_page_query)
 
         process_page_action_query = """
         INSERT INTO %s.page_4 (action_id, processed)
         VALUES (3, 'yes')
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(process_page_action_query)
 
         self.survey_results.database.commit()
@@ -165,11 +165,11 @@ class Test:
     def teardown(self):
         drop_survey_schema_query = """
         DROP SCHEMA %s CASCADE
-        """ % test_settings.DB_SCHEMA_SURVEY
+        """ % settings['DB_SCHEMA_SURVEY']
         self.survey_results.database_cursor.execute(drop_survey_schema_query)
 
         drop_ak_schema_query = """
         DROP SCHEMA %s CASCADE
-        """ % test_settings.DB_SCHEMA_AK
+        """ % settings['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(drop_ak_schema_query)
         self.survey_results.database.commit()

--- a/test_ak_survey_results.py
+++ b/test_ak_survey_results.py
@@ -21,9 +21,9 @@ class Test:
         CREATE TABLE %s.pages (
             page_id INTEGER,
             last_refresh TIMESTAMP,
-            column_list VARCHAR(MAX)
+            column_list %s
         )
-        """ % settings['DB_SCHEMA_SURVEY']
+        """ % (settings['DB_SCHEMA_SURVEY'], settings['DB_VARCHAR_COL'])
         self.survey_results.database_cursor.execute(create_pages_table_query)
 
         create_ak_schema_query = """
@@ -53,9 +53,9 @@ class Test:
             id INTEGER,
             parent_id INTEGER,
             name VARCHAR(765),
-            value VARCHAR(MAX)
+            value %s
         )
-        """ % settings['DB_SCHEMA_AK']
+        """ % (settings['DB_SCHEMA_AK'], settings['DB_VARCHAR_COL'])
         self.survey_results.database_cursor.execute(
             create_actionfield_table_query
         )
@@ -89,9 +89,9 @@ class Test:
         create_page_query = """
         CREATE TABLE %s.page_4 (
             action_id INTEGER,
-            processed VARCHAR(MAX)
+            processed %s
         )
-        """ % settings['DB_SCHEMA_SURVEY']
+        """ % (settings['DB_SCHEMA_SURVEY'], settings['DB_VARCHAR_COL'])
         self.survey_results.database_cursor.execute(create_page_query)
 
         process_page_query = """


### PR DESCRIPTION
I recommend looking at the three commits separately to understand the three changes made in this pull request:

1. Updates to get secrets from AWS Secrets Manager instead of settings.py
2. Updates to allow unit tests to run on either Postgres or Redshift
3. Fix discrepancies with ARG_DEFINITIONS, REQUIRED_ARGS, and settings.py.example