### PR TITLE
Increase timeout

### DIFF
--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -16,7 +16,7 @@
         "role_name": "test_python",
         "runtime": "python3.10",
         "s3_bucket": "zappa-survey-results",
-        "timeout_seconds": 60,
+        "timeout_seconds": 300,
         "vpc_config": {
             "SubnetIds": [ "subnet-d8385681" ],
             "SecurityGroupIds": [ "sg-c2ee0da5" ]


### PR DESCRIPTION
Some queries in this repo take more than 60s to run, leading to "Task timed out..." errors. 300s timeout is sufficient time for all queries to run.