### PR TITLE
Missing survey_results table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Run `cp zappa_settings.json.example zappa_settings.json` and set any "[PICK-A-VA
 
 ## Tests
 
-To run tests:
+Grant necessary local PostgreSQL permissions:
+- `psql -h localhost -U <superuser> -d postgres`
+- `GRANT CREATE ON DATABASE postgres TO postgres;`
 
-- `cp settings.py.example test_settings.py` and fill in values. *Note*: in the test context, `DB_SCHEMA_AK` and `DB_SCHEMA_SURVEY` will be created and destroyed, so should not refer to existing schemas.
+Run tests:
 - `pip install -U pytest`
 - `pytest`
 

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -112,7 +112,11 @@ class AKSurveyResults:
             self.settings.DB_SCHEMA_SURVEY,
             int(page_id)
         )
-        self.database_cursor.execute(saved_count_query)
+        try:
+            self.database_cursor.execute(saved_count_query)
+        except psycopg2.errors.UndefinedTable as e:
+            self.database.rollback()
+            raise PageNotLoadedException from e
         saved_count_result = list(self.database_cursor.fetchall())
         result['saved_count'] = saved_count_result[0].get('saved_count', 0)
         return result

--- a/test_ak_survey_results.py
+++ b/test_ak_survey_results.py
@@ -85,7 +85,7 @@ class Test:
         INSERT INTO %s.core_page (id, type)
         VALUES
         (1, 'Donation'), (2, 'Survey'),
-        (3, 'Survey'), (4, 'Survey')
+        (3, 'Survey'), (4, 'Survey'), (5, 'Survey')
         """ % self.args['DB_SCHEMA_AK']
         self.survey_results.database_cursor.execute(page_query)
 
@@ -115,11 +115,17 @@ class Test:
         """ % (self.args['DB_SCHEMA_SURVEY'], self.survey_results.varchar_col_type)
         self.survey_results.database_cursor.execute(create_page_query)
 
-        process_page_query = """
+        process_page_query_1 = """
         INSERT INTO %s.pages (page_id, last_refresh, column_list)
         VALUES (4, '2018-10-06 01:01:01', 'processed')
         """ % self.args['DB_SCHEMA_SURVEY']
-        self.survey_results.database_cursor.execute(process_page_query)
+        self.survey_results.database_cursor.execute(process_page_query_1)
+
+        process_page_query_2 = """
+        INSERT INTO %s.pages (page_id, last_refresh, column_list)
+        VALUES (5, '2018-10-06 01:01:01', 'processed')
+        """ % self.args['DB_SCHEMA_SURVEY']
+        self.survey_results.database_cursor.execute(process_page_query_2)
 
         process_page_action_query = """
         INSERT INTO %s.page_4 (action_id, processed)
@@ -148,6 +154,8 @@ class Test:
             self.survey_results.survey_refresh_info(1)
         with pytest.raises(PageNotLoadedException) as e:
             self.survey_results.survey_refresh_info(2)
+        with pytest.raises(PageNotLoadedException):
+            self.survey_results.survey_refresh_info(5)
         results = self.survey_results.survey_refresh_info(4)
         assert results.get('action_count', 0) == 1
         assert results.get('saved_count', 0) == 1

--- a/test_ak_survey_results.py
+++ b/test_ak_survey_results.py
@@ -115,17 +115,12 @@ class Test:
         """ % (self.args['DB_SCHEMA_SURVEY'], self.survey_results.varchar_col_type)
         self.survey_results.database_cursor.execute(create_page_query)
 
-        process_page_query_1 = """
+        process_page_query = """
         INSERT INTO %s.pages (page_id, last_refresh, column_list)
-        VALUES (4, '2018-10-06 01:01:01', 'processed')
+        VALUES (4, '2018-10-06 01:01:01', 'processed'),
+        (5, '2018-10-06 01:01:01', 'processed')
         """ % self.args['DB_SCHEMA_SURVEY']
-        self.survey_results.database_cursor.execute(process_page_query_1)
-
-        process_page_query_2 = """
-        INSERT INTO %s.pages (page_id, last_refresh, column_list)
-        VALUES (5, '2018-10-06 01:01:01', 'processed')
-        """ % self.args['DB_SCHEMA_SURVEY']
-        self.survey_results.database_cursor.execute(process_page_query_2)
+        self.survey_results.database_cursor.execute(process_page_query)
 
         process_page_action_query = """
         INSERT INTO %s.page_4 (action_id, processed)


### PR DESCRIPTION
There was an error when a table was in the `survey_results.pages` table but didn't have a corresponding `survey_results.page_<page_id>` table. This PR correctly throws a `PageNotLoadedException` if that's the case.