### PR TITLE
Raise error

### DIFF
--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -497,32 +497,14 @@ def main(args):
     print(args.__dict__.get('PAGE_ID', ''), 'PAGE_ID')
     print(args.__dict__.get('SINCE', ''), 'SINCE')
     if args.FUNCTION == 'survey_refresh_info':
-        try:
-            return ak.survey_refresh_info(args.PAGE_ID)
-        except Exception as e:
-            return {
-                'error': str(e)
-            }
+        return ak.survey_refresh_info(args.PAGE_ID)
     elif args.FUNCTION == 'surveys_that_need_updating':
-        try:
-            return ak.surveys_that_need_updating(15)
-        except Exception as e:
-            return {
-                'error': str(e)
-            }
+        return ak.surveys_that_need_updating(15)
     elif args.FUNCTION == 'process_surveys_that_need_updating':
         surveys = ak.surveys_that_need_updating(15)
         return ak.process_surveys_that_need_updating(surveys, args.LAMBDA)
     elif args.FUNCTION == 'process_recent_actions_for_survey':
-        try:
-            return ak.process_recent_actions_for_survey(
-                args.PAGE_ID,
-                args.SINCE
-            )
-        except Exception as e:
-            return {
-                'error': str(e)
-            }
+        return ak.process_recent_actions_for_survey(args.PAGE_ID, args.SINCE)
     return False
 
 

--- a/ak_survey_results.py
+++ b/ak_survey_results.py
@@ -511,13 +511,8 @@ def main(args):
                 'error': str(e)
             }
     elif args.FUNCTION == 'process_surveys_that_need_updating':
-        try:
-            surveys = ak.surveys_that_need_updating(15)
-            return ak.process_surveys_that_need_updating(surveys, args.LAMBDA)
-        except Exception as e:
-            return {
-                'error': str(e)
-            }
+        surveys = ak.surveys_that_need_updating(15)
+        return ak.process_surveys_that_need_updating(surveys, args.LAMBDA)
     elif args.FUNCTION == 'process_recent_actions_for_survey':
         try:
             return ak.process_recent_actions_for_survey(


### PR DESCRIPTION
If an error happens, MoveOn is not alerted since the exception is caught but not raised. I believe the try/except should be removed so that the exception can be raised if it happens. Let me know if there's a reason why it shouldn't be.