### PR TITLE
Update requirements.txt for Lambda compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 awesome-slugify==1.6.5
-boto3==1.17.28
+boto3==1.34.42
 psycopg2-binary==2.9.5
 zappa>=0.54.0
 mo-pywell==1.1.0
 moto[secretsmanager]==4.0.9
 pytest
+
+# botocore does not support urllib3 2.0 yet: https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html#importerror-cannot-import-name-default-ciphers-from-urllib3-util-ssl
+urllib3<2


### PR DESCRIPTION
The following error occurred when running `zappa update`:
```
Unknown parameter in input: "EphemeralStorage", must be one of: FunctionName, Role, Handler, Description, Timeout, MemorySize, VpcConfig, Environment, Runtime, DeadLetterConfig, KMSKeyArn, TracingConfig, RevisionId, Layers, FileSystemConfigs, ImageConfig
```

[This article](https://repost.aws/knowledge-center/lambda-python-runtime-errors) indicates that an AWS CLI and/or `boto3` upgrade was needed. Upgrading the AWS CLI resulted in the same error, and upgrading `boto3` resolved the error.

After deployment, however, the Lambda had the following error:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'ak_survey_results': cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'
```

This is because `botocore` does not support `urllib3` 2.0 yet, so the urllib3 version needs to be pinned. [Source](https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html#importerror-cannot-import-name-default-ciphers-from-urllib3-util-ssl).

After making the changes in this PR, the repo was able to be successfully deployed and ran.